### PR TITLE
change modal-window__text font-size to 35px

### DIFF
--- a/client/styles/main/bloks/modal-window.scss
+++ b/client/styles/main/bloks/modal-window.scss
@@ -7,7 +7,7 @@
 
 .modal-window__text {
   margin: 10px;
-  font-size: 30px;
+  font-size: 35px;
   border-radius: 7px;
   color: rgb(238, 46, 46);
   font-weight: 700;


### PR DESCRIPTION
Test change. Font-size of font of modal window is set to 35px instead of 30px. 